### PR TITLE
Fix scipy polyval import

### DIFF
--- a/galore/cross_sections.py
+++ b/galore/cross_sections.py
@@ -5,9 +5,8 @@ from json import load as json_load
 
 
 import sqlite3
-from scipy import polyval
 from numpy import fromstring as np_fromstr
-from numpy import exp, log
+from numpy import exp, log, polyval
 
 
 def get_cross_sections(weighting, elements=None):


### PR DESCRIPTION
This fixes an error when running `galore` from the current `master` branch:

```
galore -h
Traceback (most recent call last):
  File "/Users/kavanase/miniconda3/bin/galore", line 33, in <module>
    sys.exit(load_entry_point('galore', 'console_scripts', 'galore')())
  File "/Users/kavanase/miniconda3/bin/galore", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/Users/kavanase/miniconda3/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/Users/kavanase/miniconda3/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/kavanase/Packages/galore/galore/__init__.py", line 34, in <module>
    from galore.cross_sections import get_cross_sections, cross_sections_info
  File "/Users/kavanase/Packages/galore/galore/cross_sections.py", line 8, in <module>
    from scipy import polyval
ImportError: cannot import name 'polyval' from 'scipy' (/Users/kavanase/miniconda3/lib/python3.10/site-packages/scipy/__init__.py)
❯ pip install -U scipy
Requirement already satisfied: scipy in /Users/kavanase/miniconda3/lib/python3.10/site-packages (1.13.1)
Collecting scipy
  Downloading scipy-1.14.1-cp310-cp310-macosx_14_0_arm64.whl.metadata (60 kB)
Requirement already satisfied: numpy<2.3,>=1.23.5 in /Users/kavanase/miniconda3/lib/python3.10/site-packages (from scipy) (1.26.4)
Downloading scipy-1.14.1-cp310-cp310-macosx_14_0_arm64.whl (23.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 23.1/23.1 MB 20.6 MB/s eta 0:00:00
Installing collected packages: scipy
  Attempting uninstall: scipy
    Found existing installation: scipy 1.13.1
    Uninstalling scipy-1.13.1:
      Successfully uninstalled scipy-1.13.1
Successfully installed scipy-1.14.1
❯ galore -h
Traceback (most recent call last):
  File "/Users/kavanase/miniconda3/bin/galore", line 33, in <module>
    sys.exit(load_entry_point('galore', 'console_scripts', 'galore')())
  File "/Users/kavanase/miniconda3/bin/galore", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/Users/kavanase/miniconda3/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/Users/kavanase/miniconda3/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/kavanase/Packages/galore/galore/__init__.py", line 34, in <module>
    from galore.cross_sections import get_cross_sections, cross_sections_info
  File "/Users/kavanase/Packages/galore/galore/cross_sections.py", line 8, in <module>
    from scipy import polyval
ImportError: cannot import name 'polyval' from 'scipy' (/Users/kavanase/miniconda3/lib/python3.10/site-packages/scipy/__init__.py)
```

With the updated code, running `galore` works fine