### PR TITLE
Deal with matplotlib 3.6 deprecation/rename of seaborn-colorblind

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Versioning <http://semver.org/>`__. The changelog format is inspired by
 `Unreleased <https://github.com/smtg-ucl/galore/compare/0.9.0...HEAD>`__
 -------------------------------------------------------------------------
 - Deal with matplotlib 3.6 deprecation/rename of seaborn-colorblind (@ajjackson)
+- Deal with scipy deprecation of polyval (@kavanase)
 
 
 `[0.9.0] <https://github.com/smtg-ucl/galore/compare/0.8.0...0.9.0>`__ - 2023-08-14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,11 @@ Versioning <http://semver.org/>`__. The changelog format is inspired by
 
 `Unreleased <https://github.com/smtg-ucl/galore/compare/0.9.0...HEAD>`__
 -------------------------------------------------------------------------
-- Deal with matplotlib 3.6 deprecation/rename of seaborn-colorblind (@ajjackson)
+- Deal with matplotlib compatibility issues (@ajjackson)
+
+  -  3.6 deprecation/rename of seaborn-colorblind
+  -  Use public API to get line colour more robustly
+
 - Deal with scipy deprecation of polyval (@kavanase)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Versioning <http://semver.org/>`__. The changelog format is inspired by
 
 `Unreleased <https://github.com/smtg-ucl/galore/compare/0.9.0...HEAD>`__
 -------------------------------------------------------------------------
+- Deal with matplotlib 3.6 deprecation/rename of seaborn-colorblind (@ajjackson)
+
 
 `[0.9.0] <https://github.com/smtg-ucl/galore/compare/0.8.0...0.9.0>`__ - 2023-08-14
 -----------------------------------------------------------------------------------

--- a/galore/cli/galore.py
+++ b/galore/cli/galore.py
@@ -29,6 +29,7 @@ import warnings
 import numpy as np
 
 import galore
+from galore.cli.utils import get_default_style
 import galore.formats
 import galore.plot
 from galore import auto_limits
@@ -287,9 +288,9 @@ def get_parser():
     parser.add_argument(
         '--ymax', type=float, default=None, help='Maximum y axis value')
     parser.add_argument(
-        '--style', type=str, nargs='+', default=['seaborn-colorblind'],
+        '--style', type=str, nargs='+', default=get_default_style(),
         help='Plotting style: a sequence of matplotlib styles and paths to '
-             'style files. The default palette is called "seaborn-colorblind".'
+             'style files.'
         )
     parser.add_argument(
         '--overlay', type=str, default=None, help='Data file for overlay')

--- a/galore/cli/galore_plot_cs.py
+++ b/galore/cli/galore_plot_cs.py
@@ -25,8 +25,8 @@ from itertools import cycle
 import logging
 import numpy as np
 from matplotlib import pyplot as plt
-plt.style.use('seaborn-colorblind')
 
+from galore.cli import get_default_style
 from galore.cross_sections import get_cross_sections_scofield
 
 
@@ -52,9 +52,9 @@ def get_parser():
     parser.add_argument('--fontsize', type=int, default=12,
                         help="Font size in pt")
     parser.add_argument(
-        '--style', type=str, nargs='+', default=['seaborn-colorblind'],
+        '--style', type=str, nargs='+', default=get_default_style(),
         help='Plotting style: a sequence of matplotlib styles and paths to '
-             'style files. The default palette is called "seaborn-colorblind".'
+             'style files.'
         )
     parser.add_argument('elements', type=str, nargs='+', help="""
         Space-separated symbols for elements in material.""")
@@ -67,8 +67,7 @@ def run(elements, emin=1, emax=10, megabarn=False, size=None, output=None,
     energies = np.linspace(emin, emax, 200)
     cross_sections = get_cross_sections_scofield(energies, elements)
 
-    if style is not None:
-        plt.style.use(style)
+    plt.style.use(style)
 
     if size is None:
         fig = plt.figure()

--- a/galore/cli/utils.py
+++ b/galore/cli/utils.py
@@ -1,0 +1,12 @@
+"""Utility functions used by command-line tools"""
+
+import matplotlib
+from packaging.version import Version
+
+def get_default_style() -> str:
+    """Get appropriate name for seaborn-colorblind, depending on MPL version"""
+
+    if Version(matplotlib) < Version("3.6"):
+        return "seaborn-colorblind"
+
+    return "seaborn-v0_8-colorblind"

--- a/galore/cli/utils.py
+++ b/galore/cli/utils.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 def get_default_style() -> str:
     """Get appropriate name for seaborn-colorblind, depending on MPL version"""
 
-    if Version(matplotlib) < Version("3.6"):
+    if Version(matplotlib.__version__) < Version("3.6"):
         return "seaborn-colorblind"
 
     return "seaborn-v0_8-colorblind"

--- a/galore/plot.py
+++ b/galore/plot.py
@@ -158,15 +158,14 @@ def plot_pdos(pdos_data, ax=None, total=True, show_orbitals=True, offset=0., fli
                 max_y = max(max_y, max(el_data[orbital]))
 
             if show_orbitals:
-                color = next(ax._get_lines.prop_cycler)['color'] # get color to ensure
-                # matching fill
                 label = (None if max(el_data[orbital]) < legend_cutoff * tmax
                          else "{0}: {1}".format(element, orbital))
-                ax.plot(x_data, el_data[orbital], color=color, label=label,
-                        marker='', linestyle=next(linecycler))
+                (line2d, ) = ax.plot(x_data, el_data[orbital], label=label,
+                                     marker='', linestyle=next(linecycler))
 
                 if fill:
-                    ax.fill_between(x_data, el_data[orbital], color=color, alpha=alpha)
+                    ax.fill_between(x_data, el_data[orbital],
+                                    color=line2d.get_color(), alpha=alpha)
 
     if total:
         max_y = max(tdos)

--- a/galore/plot.py
+++ b/galore/plot.py
@@ -1,11 +1,11 @@
 """Plotting routines with Matplotlib"""
 from collections import defaultdict
-from os.path import basename as path_basename
 from itertools import cycle
+from os.path import basename as path_basename
 import logging
 
-import numpy as np
 from matplotlib import pyplot as plt
+import numpy as np
 
 from galore import auto_limits
 import galore.formats


### PR DESCRIPTION
Matplotlib changed the name of our default colour theme (presumably to be future-proof against defaults of later seaborn versions?)

As both this and #51 address test failures, they should each be merged into `develop` and then when tests pass `develop` can be merged to master.

It's not quite git-flow but it works.